### PR TITLE
Fix GitHub Actions permissions for gh-pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add write permissions for contents, pages, and id-token to allow the GitHub Actions bot to push documentation to the gh-pages branch.